### PR TITLE
Single quoting 'type' as it is a reserved word and '300' to prevent evaluation errors.

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -25,7 +25,7 @@
 #
 define r9util::download(
   $url     = $title,
-  $timeout = 300,
+  $timeout = '300',
   $path    = undef,
   $md5sum  = undef,
 ){

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -122,7 +122,7 @@ define r9util::system_user(
 
       $ssh_authkey_defaults = {
         user    => $user,
-        type    => 'ssh-rsa',
+        'type'    => 'ssh-rsa',
       }
 
       create_resources('ssh_authorized_key',$auth_keys,$ssh_authkey_defaults)


### PR DESCRIPTION
As title suggests, single quoting 'type' as it is a reserved word and '300' to prevent evaluation errors.
